### PR TITLE
Issue #176: Copy "resources" folder in toolkit:build-dist.

### DIFF
--- a/src/TaskRunner/Commands/BuildCommands.php
+++ b/src/TaskRunner/Commands/BuildCommands.php
@@ -59,6 +59,14 @@ class BuildCommands extends AbstractCommands {
       ->copy('./composer.json', $options['dist-root'] . '/composer.json')
       ->copy('./composer.lock', $options['dist-root'] . '/composer.lock');
 
+    // Symlink resources folder (use it for e.g. composer patches).
+    $resourcesDir = './resources';
+    $resourcesDirExists = is_dir($resourcesDir);
+    if ($resourcesDirExists) {
+      $tasks[] = $this->taskFilesystemStack()
+        ->symlink(realpath($resourcesDir), $options['dist-root'] . '/resources');
+    }
+
     // Copy site configuration.
     $tasks[] = $this->taskCopyDir(['./config' => $options['dist-root'] . '/config']);
 
@@ -77,6 +85,12 @@ class BuildCommands extends AbstractCommands {
     $commands = $this->getConfig()->get("toolkit.build.dist.commands");
     if (!empty($commands)) {
       $tasks[] = $this->taskCollectionFactory($commands);
+    }
+
+    // Remove resources symlink.
+    if ($resourcesDirExists) {
+      $tasks[] = $this->taskFilesystemStack()
+        ->remove($options['dist-root'] . '/resources');
     }
 
     // Build and return task collection.


### PR DESCRIPTION
See https://github.com/ec-europa/toolkit/issues/176
This allows, among other things, use of local patches in composer.json.