### PR TITLE
Update documentation

### DIFF
--- a/docs/testing-project.md
+++ b/docs/testing-project.md
@@ -402,7 +402,7 @@ and check if your build is compatible with PHP 7.
 You can control the way it's run with the following properties:
 ```
 # Compatibility settings.
-phpcs.compat.version = 7.0-
+phpcs.compat.version = 7.2
 phpcs.compat.checkreturn = true
 phpcs.compat.skip = false
 ```


### PR DESCRIPTION
In the release `3.0.23` the variable `phpcs.compat.version` was changed to 7.2 (MULTISITE-21981) but the documentation was not updated.