### PR TITLE
Typo in ignore_warnings_on_exit

### DIFF
--- a/includes/phing/build/test/phpcs.xml
+++ b/includes/phing/build/test/phpcs.xml
@@ -33,7 +33,7 @@
                     standards="PHPCompatibility"
                 />
                 <exec
-                    command="${toolkit.dir.bin}/phpcs --config-set ignore_warnins_on_exit ${phpcs.passwarnings} >/dev/null"
+                    command="${toolkit.dir.bin}/phpcs --config-set ignore_warnings_on_exit ${phpcs.passwarnings} >/dev/null"
                     passthru="true"
                     checkreturn="true"
                 />
@@ -72,7 +72,7 @@
             standards="${phpcs.standards}"
         />
         <exec
-            command="${toolkit.dir.bin}/phpcs --config-set ignore_warnins_on_exit ${phpcs.passwarnings} >/dev/null"
+            command="${toolkit.dir.bin}/phpcs --config-set ignore_warnings_on_exit ${phpcs.passwarnings} >/dev/null"
             passthru="true"
             checkreturn="true"
         />

--- a/includes/phing/build/test/phpcs.xml
+++ b/includes/phing/build/test/phpcs.xml
@@ -44,7 +44,7 @@
                 />
             </then>
             <else>
-                <echo msg="Skipping PHPCS Compatibility checks alltogether." />
+                <echo msg="Skipping PHPCS Compatibility checks altogether." />
             </else>
         </if>
     </target>


### PR DESCRIPTION
PHP_CodeSniffer Wiki 
https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#ignoring-warnings-when-generating-the-exit-code

I believe this should be `ignore_warnings_on_exit` instead of `ignore_warnins_on_exit`