### PR TITLE
MULTISITE-22082: Avoid wrong name for site-name

### DIFF
--- a/includes/phing/build/help/drush.xml
+++ b/includes/phing/build/help/drush.xml
@@ -349,7 +349,7 @@
         <echo message="Installing site ${project.name}." />
         <drush command="site-install" assume="yes" root="${build.platform.dir}" bin="${toolkit.dir.bin.drush}" alias="@${drush.alias.default}" verbose="${drush.verbose}" color="${drush.color}">
             <option name="db-url" value="${db.url}" />
-            <option name="site-name" value="'${project.name}'" />
+            <option name="site-name" value="${project.name}" />
             <option name="account-name" value="${admin.username}" />
             <option name="account-pass" value="${admin.password}" />
             <option name="account-mail" value="${admin.email}" />


### PR DESCRIPTION
Without this change I have a site-name with an extra upper-comma
![site_install_logo](https://user-images.githubusercontent.com/1574795/64183217-d6137c80-ce69-11e9-9f0c-c1d432dd8c2d.png)
![site_name_settings](https://user-images.githubusercontent.com/1574795/64183218-d6137c80-ce69-11e9-9d59-d8ac80f39dc2.png)
