### PR TITLE
MULTISITE-22865: Make sure that the update module is disabled

### DIFF
--- a/includes/drush/custom/toolkit.drush.inc
+++ b/includes/drush/custom/toolkit.drush.inc
@@ -69,9 +69,8 @@ function drush_toolkit_check_modules_authorized_security($project_id = NULL) {
     // Check update module status.
     $updateStatus = system_get_info('module', 'update');
     // Enable 'Update Manager' module if it's disabled.
-    if (empty($updateStatus)) {
-      $updateModule = array('update');
-      module_enable($updateModule, FALSE);
+    if (!module_exists('update') && empty($updateStatus)) {
+      module_enable(array('update'), FALSE);
       $status = FALSE;
     }
     else {
@@ -138,8 +137,7 @@ function drush_toolkit_check_modules_authorized_security($project_id = NULL) {
     }
     // Turn off again 'Update Manager' module, in case was initially disabled.
     if ($status != TRUE) {
-      $updateModule = array('update');
-      module_disable($updateModule, FALSE);
+      module_disable(array('update'), FALSE);
       unset($status);
     }
     // Delete variable 'project_id'.

--- a/includes/drush/custom/toolkit.drush.inc
+++ b/includes/drush/custom/toolkit.drush.inc
@@ -66,10 +66,8 @@ function drush_toolkit_check_modules_authorized_security($project_id = NULL) {
     if ($project_id !== NULL) {
       variable_set('project_id', $project_id);
     }
-    // Check update module status.
-    $updateStatus = system_get_info('module', 'update');
     // Enable 'Update Manager' module if it's disabled.
-    if (!module_exists('update') && empty($updateStatus)) {
+    if (!module_exists('update')) {
       module_enable(array('update'), FALSE);
       $status = FALSE;
     }


### PR DESCRIPTION
If the module update is already enabled when the `drush toolkit-check-modules-authorized-security` is called, it will throw a error.
Here I'm proposing the usage of the function `module_exists()` to really make sure that the module is disabled.
An example of the problem can be found at https://drone.fpfis.eu/ec-europa/comm-cwt2019-reference/50/17
I got the same error while testing locally.

Also, removed a declaration of variable that is only used there, if you don't want this change I can revert.