### PR TITLE
MULTISITE-23072: Return latest from specified major version.

### DIFF
--- a/includes/phing/src/Tasks/PlatformVersionsTask.php
+++ b/includes/phing/src/Tasks/PlatformVersionsTask.php
@@ -128,7 +128,15 @@ class PlatformVersionsTask extends \Task
         );
 
         // Check if the project is using the latest version, if not let user know.
+        $shortPackageVersionSet = substr($this->_packageVersion, 0, 3);
+        $shortPackageVersionLatest = substr($latest_version, 0, 3);
+
+        if ($shortPackageVersionSet != $shortPackageVersionLatest) {
+            $latest_version = $majors[$shortPackageVersionSet];
+        }
+
         $this->setLatestProp($latest_version);
+
         if ($this->versionprop != $latest_version) {
             $this->log(
                 "Please upgrade your project recommended version " . $latest_version  . ".",


### PR DESCRIPTION
As core team is maintaining 2 major versions, the latest tag returned by GitHub API is the tag with TAG that contains the newer commit date (2.5 most part of times) even if developer is already using 2.6. This commit allow to have latest version by major version.