### PR TITLE
MULTISITE-23428: Release 4.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require": {
         "php": "^7.1",
         "cweagans/composer-patches": "^1.4",
-        "drupal/drupal-extension": "^3.4 || ^4.0",
         "drush/drush": "^9.7.1 || ^10.0.0",
         "ec-europa/qa-automation": "^4.0.0",
         "guzzlehttp/guzzle": "^6.3",

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,6 +9,9 @@ toolkit:
     config_file: 'config/sync/core.extension.yml'
     sequence_file: '.opts.yml'
     sequence_key: 'upgrade_commands'
+  install:
+    clone:
+      commands: []
   build:
     dist:
       root: 'dist'

--- a/docs/installing-project.md
+++ b/docs/installing-project.md
@@ -49,6 +49,17 @@ Toolkit will load the credentials necessary to download the sanitized database d
 - ASDA_PASSWORD
 ```
 
+If you want to run extra commands after the `toolkit:install-clone` command you
+can configure the following in your `runner.yml.dist` file:
+
+```yaml
+toolkit:
+  install:
+    clone:
+      commands:
+        - ./vendor/bin/drush status
+```
+
 When running the command toolkit:install-clone it will run the following sequence of commands after the database import:
 
 ```

--- a/src/TaskRunner/Commands/BuildCommands.php
+++ b/src/TaskRunner/Commands/BuildCommands.php
@@ -140,6 +140,19 @@ class BuildCommands extends AbstractCommands
             $tasks[] = $this->taskCollectionFactory($commands);
         }
 
+        // Double check presence of required folders.
+        $folders = [
+            'private_folder' => getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== false ? $options['root'] . '/' . getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : $options['root'] . '/sites/default/private_files',
+            'temp_folder' => getenv('DRUPAL_FILE_TEMP_PATH') !== false ? getenv('DRUPAL_FILE_TEMP_PATH') : '/tmp',
+        ];
+        
+        foreach ($folders as $folder) {
+            if (!is_dir($folder)) {
+                $tasks[] = $this->taskFilesystemStack()
+                    ->mkdir($folder);
+            }
+        }
+
         // Build and return task collection.
         return $this->collectionBuilder()->addTaskList($tasks);
     }

--- a/src/TaskRunner/Commands/BuildCommands.php
+++ b/src/TaskRunner/Commands/BuildCommands.php
@@ -151,14 +151,14 @@ class BuildCommands extends AbstractCommands
         foreach ($folders as $folder) {
             if (!is_dir($folder)) {
                 // Create folder and set permissions.
+                // Permissions for files folders taken from:
+                // https://www.drupal.org/node/244924#linux-servers
                 $tasks[] = $this->taskExecStack()
                     ->stopOnFail()
                     ->exec("mkdir -p $folder")
-                    // Permissions for files folders taken from:
-                    // https://www.drupal.org/node/244924#linux-servers
                     ->exec("find $folder -type d -exec chmod ug=rwx,o= '{}' \;")
                     ->exec("find $folder -type f -exec chmod ug=rw,o= '{}' \;");
-                }
+            }
         }
 
         // Build and return task collection.

--- a/src/TaskRunner/Commands/BuildCommands.php
+++ b/src/TaskRunner/Commands/BuildCommands.php
@@ -145,13 +145,19 @@ class BuildCommands extends AbstractCommands
             'private_folder' => getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== false ? $options['root'] . '/' . getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : $options['root'] . '/sites/default/private_files',
             'temp_folder' => getenv('DRUPAL_FILE_TEMP_PATH') !== false ? getenv('DRUPAL_FILE_TEMP_PATH') : '/tmp',
         ];
-        
+
         foreach ($folders as $folder) {
             if (!is_dir($folder)) {
                 $tasks[] = $this->taskFilesystemStack()
                     ->mkdir($folder);
             }
         }
+
+        // Update permissions of /files folder.
+        $tasks[] = $this->taskGitStack()
+            ->stopOnFail()
+            ->exec("find . -type d -path './sites/default/files' -exec chmod g+ws {} \;")
+            ->exec("find . -type f -path './sites/default/files/*' -exec chmod 664 {} \;");
 
         // Build and return task collection.
         return $this->collectionBuilder()->addTaskList($tasks);
@@ -175,7 +181,7 @@ class BuildCommands extends AbstractCommands
     ])
     {
         $tasks = [];
-        
+
         $question = 'Are you sure you want to proceed? This action cleans up your git repository of any tracked AND untracked files AND folders!';
         if ($this->confirm($question, false)) {
             // Clean git.

--- a/src/TaskRunner/Commands/BuildCommands.php
+++ b/src/TaskRunner/Commands/BuildCommands.php
@@ -156,8 +156,7 @@ class BuildCommands extends AbstractCommands
                 $tasks[] = $this->taskExecStack()
                     ->stopOnFail()
                     ->exec("mkdir -p $folder")
-                    ->exec("find $folder -type d -exec chmod ug=rwx,o= '{}' \;")
-                    ->exec("find $folder -type f -exec chmod ug=rw,o= '{}' \;");
+                    ->exec("chmod ug=rwx,o= $folder");
             }
         }
 

--- a/src/TaskRunner/Commands/CloneCommands.php
+++ b/src/TaskRunner/Commands/CloneCommands.php
@@ -232,7 +232,8 @@ class CloneCommands extends AbstractCommands
     }
 
     /**
-     * Create file with full url to be dowloaded.
+     * Create file for usage in wget --input-file argument in the
+     * downloadDump() function.
      *
      * @param string $filename
      *   Name of filename to append to url.

--- a/src/TaskRunner/Commands/CloneCommands.php
+++ b/src/TaskRunner/Commands/CloneCommands.php
@@ -168,17 +168,17 @@ class CloneCommands extends AbstractCommands
             return $this->collectionBuilder()->addTaskList($tasks);
         }
 
-        // Download the file.
+        // Download the .sha file.
+        $this->buildDownloadLink('latest.sh1', $options);
         $this->downloadChecksumFile($options);
         $fileContent = file_get_contents('latest.sh1');
         $filename = trim(explode('  ', $fileContent)[1]);
 
-        // Download the file.
+        // Download the .sql file.
+        $this->buildDownloadLink($filename, $options);
         $tasks[] = $this->taskExec('wget')
-            ->option('--http-user', $options['asda-user'])
-            ->option('--http-password', $options['asda-password'])
             ->option('-O', $options['dumpfile'] . '.gz')
-            ->option('-nH', $options['asda-url'] . '/' . $filename)
+            ->option('-i', 'downloadLink.txt')
             ->option('-A', 'sql.gz')
             ->option('-P', './');
 
@@ -186,9 +186,10 @@ class CloneCommands extends AbstractCommands
         $tasks[] = $this->taskExec('gunzip')
             ->arg($options['dumpfile'] . '.gz');
 
-        // Remove checkum file.
+        // Remove temporary files.
         $tasks[] = $this->taskExec('rm')
-            ->arg('latest.sh1');
+            ->arg('latest.sh1')
+            ->arg('downloadLink.txt');
 
         // Build and return task collection.
         return $this->collectionBuilder()->addTaskList($tasks);
@@ -218,12 +219,45 @@ class CloneCommands extends AbstractCommands
             ->run();
 
         $this->taskExec('wget')
-            ->option('--http-user', $options['asda-user'])
-            ->option('--http-password', $options['asda-password'])
+            ->option('-i', 'downloadLink.txt')
             ->option('-O', 'latest.sh1')
-            ->option('-nH', $options['asda-url'] . '/latest.sh1')
             ->option('-A', '.sh1')
             ->option('-P', './')
+            ->run();
+    }
+
+    /**
+     * Create file with full url to be dowloaded.
+     *
+     * Make use of --input file to make sure credentials are not
+     * exposed in the logs.
+     *
+     * @param string $filename
+     *   Name of filename to append to url.
+     *
+     * @param array $options
+     *   Command options.
+     */
+    private function buildDownloadLink($filename, array $options = [
+        'asda-url' => InputOption::VALUE_REQUIRED,
+        'asda-user' => InputOption::VALUE_REQUIRED,
+        'asda-password' => InputOption::VALUE_REQUIRED,
+        'dumpfile' => InputOption::VALUE_REQUIRED,
+    ])
+    {
+
+        $disallowed = array('http://', 'https://');
+        foreach ($disallowed as $d) {
+            if (strpos($options['asda-url'], $d) === 0) {
+                $url = str_replace($d, '', $options['asda-url']);
+            }
+        }
+
+        $downloadLink = 'https://' . $options['asda-user'] . ':' . $options['asda-password'] . '@' . $url . '/' . $filename;
+
+        $tasks[] = $this->taskFilesystemStack()
+            ->taskWriteToFile('downloadLink.txt')
+            ->line($downloadLink)
             ->run();
     }
 }

--- a/src/TaskRunner/Commands/CloneCommands.php
+++ b/src/TaskRunner/Commands/CloneCommands.php
@@ -183,7 +183,7 @@ class CloneCommands extends AbstractCommands
         $this->generateAsdaWgetInputFile($filename, $options);
         $tasks[] = $this->taskExec('wget')
             ->option('-O', $options['dumpfile'] . '.gz')
-            ->option('-i', this::TEMP_INPUTFILE)
+            ->option('-i', self::TEMP_INPUTFILE)
             ->option('-A', 'sql.gz')
             ->option('-P', './');
 
@@ -194,7 +194,7 @@ class CloneCommands extends AbstractCommands
         // Remove temporary files.
         $tasks[] = $this->taskExec('rm')
             ->arg('latest.sh1')
-            ->arg(this::TEMP_INPUTFILE);
+            ->arg(self::TEMP_INPUTFILE);
 
         // Build and return task collection.
         return $this->collectionBuilder()->addTaskList($tasks);
@@ -224,7 +224,7 @@ class CloneCommands extends AbstractCommands
             ->run();
 
         $this->taskExec('wget')
-            ->option('-i', this::TEMP_INPUTFILE)
+            ->option('-i', self::TEMP_INPUTFILE)
             ->option('-O', 'latest.sh1')
             ->option('-A', '.sh1')
             ->option('-P', './')
@@ -258,7 +258,7 @@ class CloneCommands extends AbstractCommands
         $downloadLink = 'https://' . $options['asda-user'] . ':' . $options['asda-password'] . '@' . $url . '/' . $filename;
 
         $tasks[] = $this->taskFilesystemStack()
-            ->taskWriteToFile(this::TEMP_INPUTFILE)
+            ->taskWriteToFile(self::TEMP_INPUTFILE)
             ->line($downloadLink)
             ->run();
     }

--- a/src/TaskRunner/Commands/DrupalCommands.php
+++ b/src/TaskRunner/Commands/DrupalCommands.php
@@ -150,7 +150,7 @@ class DrupalCommands extends Drupal8Commands
 );
 
 // Location of the site configuration files, relative to the site root.
-\$config_directories['sync'] = '../config/sync';
+\$settings['config_sync_directory'] = '../config/sync';
 
 \$settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : '{$hashSalt}';
 \$settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';

--- a/src/TaskRunner/Commands/InstallCommands.php
+++ b/src/TaskRunner/Commands/InstallCommands.php
@@ -69,6 +69,12 @@ class InstallCommands extends AbstractCommands
         $tasks[] = $this->taskExec('./vendor/bin/run toolkit:install-dump');
         $tasks[] = $this->taskExec('./vendor/bin/run toolkit:run-deploy');
 
+        // Collect and execute list of commands set on local runner.yml.
+        $commands = $this->getConfig()->get("toolkit.install.clone.commands");
+        if (!empty($commands)) {
+            $tasks[] = $this->taskCollectionFactory($commands);
+        }
+
         // Build and return task collection.
         return $this->collectionBuilder()->addTaskList($tasks);
     }

--- a/src/TaskRunner/Commands/InstallCommands.php
+++ b/src/TaskRunner/Commands/InstallCommands.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 class InstallCommands extends AbstractCommands
 {
 
+    use TaskRunnerTasks\CollectionFactory\loadTasks;
     use TaskRunnerTasks\Drush\loadTasks;
 
     /**

--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -67,14 +67,14 @@ class ToolCommands extends AbstractCommands
     }
 
     /**
-     * Check composer.json for components that are not whitelisted.
+     * Check composer.json for components that are not whitelisted/blacklisted.
      *
-     * @command toolkit:whitelist-components
+     * @command toolkit:component-check
      *
-     * @option endpoint The endpoint for the components whitelist
+     * @option endpoint The endpoint for the components whitelist/blacklist
      * @option blocker  Whether or not the command should exit with errorstatus
      */
-    public function whitelistComponents(array $options = [
+    public function componentCheck(array $options = [
         'endpoint' => InputOption::VALUE_REQUIRED,
         'blocker' => InputOption::VALUE_REQUIRED,
         'test-command' => false,
@@ -83,7 +83,7 @@ class ToolCommands extends AbstractCommands
         // Currently undocumented in this class. Because I don't know how to
         // provide such a property to one single function other than naming the
         // failed property exaclty for this function.
-        $this->whitelistComponentsFailed = false;
+        $this->componentCheckFailed = false;
         $blocker = $options['blocker'];
         $endpointUrl = $options['endpoint'];
         $basicAuth = getenv('QA_API_BASIC_AUTH') !== false ? getenv('QA_API_BASIC_AUTH') : '';
@@ -144,13 +144,13 @@ class ToolCommands extends AbstractCommands
     protected function returnStatus($blocker)
     {
         // If the validation failed and we have a blocker, then return 1.
-        if ($this->whitelistComponentsFailed && $blocker) {
+        if ($this->componentCheckFailed && $blocker) {
             $this->io()->error('Failed the components whitelist check. Please contact the QA team.');
             return 1;
         }
 
         // If the validation failed and blocker was disabled, then return 0.
-        if ($this->whitelistComponentsFailed && !$blocker) {
+        if ($this->componentCheckFailed && !$blocker) {
             $this->io()->warning('Failed the components whitelist check. Please contact the QA team.');
             return 0;
         }
@@ -180,7 +180,7 @@ class ToolCommands extends AbstractCommands
             // If module was not reviewed yet.
             if (!$hasBeenQaEd) {
                 $this->say("Package $packageName:$packageVersion has not been reviewed by QA.");
-                $this->whitelistComponentsFailed = true;
+                $this->componentCheckFailed = true;
             }
 
             // If module was rejected.
@@ -190,7 +190,7 @@ class ToolCommands extends AbstractCommands
                 // If module was not allowed in project.
                 if (!$allowedInProject) {
                     $this->say("Package $packageName:$packageVersion has been rejected by QA.");
-                    $this->whitelistComponentsFailed = true;
+                    $this->componentCheckFailed = true;
                 }
             }
 
@@ -203,7 +203,7 @@ class ToolCommands extends AbstractCommands
 
                     if (!is_null($constraintValue) && Semver::satisfies($packageVersion, $constraintValue) === $result) {
                         $this->say("Package $packageName:$packageVersion does not meet the $constraint version constraint: $constraintValue.");
-                        $this->whitelistComponentsFailed = true;
+                        $this->componentCheckFailed = true;
                     }
                 }
             }

--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace EcEuropa\Toolkit\TaskRunner\Commands;
 
+use Composer\Semver\Semver;
 use Symfony\Component\Console\Input\InputOption;
 use OpenEuropa\TaskRunner\Commands\AbstractCommands;
 

--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -198,7 +198,7 @@ class ToolCommands extends AbstractCommands
                 # Once all projects are using Toolkit >=4.1.0, the 'version' key
                 # may be removed from the endpoint: /api/v1/package-reviews.
                 $constraints = [ 'whitelist' => false, 'blacklist' => true ];
-                foreach($constraints as $constraint => $result) {
+                foreach ($constraints as $constraint => $result) {
                     $constraintValue = !empty($modules[$packageName][$constraint]) ? $modules[$packageName][$constraint] : null;
 
                     if (!is_null($constraintValue) && Semver::satisfies($packageVersion, $constraintValue) === $result) {

--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -103,18 +103,18 @@ class ToolCommands extends AbstractCommands
                     // Lines below shoul trow a warning.
                     ['type' => 'drupal-module', 'version' => '1.0', 'name' => 'drupal/unreviewed'],
                     ['type' => 'drupal-module', 'version' => '1.0', 'name' => 'drupal/devel'],
-                    ['type' => 'drupal-module', 'version' => '1.0', 'name' => 'drupal/allowed_formats'],
+                    ['type' => 'drupal-module', 'version' => '1.0-alpha1', 'name' => 'drupal/xmlsitemap'],
                     // Allowed for single project jrc-k4p, otherwise trows warning.
                     ['type' => 'drupal-module', 'version' => '1.0', 'name' => 'drupal/active_facet_pills'],
-                    // Allowed dev version if the Drupal version is bigger than
-                    // the minimum required version.
+                    // Allowed dev version if the Drupal version meets the
+                    // conflict version constraints.
                     [
                         'version' => 'dev-1.x',
                         'type' => 'drupal-module',
-                        'name' => 'drupal/autologout',
+                        'name' => 'drupal/views_bulk_operations',
                         'extra' => [
                             'drupal' => [
-                                'version' => '8.x-1.0+15-dev'
+                                'version' => '8.x-3.4+15-dev'
                             ]
                         ]
                     ]
@@ -179,7 +179,7 @@ class ToolCommands extends AbstractCommands
         if (isset($package['type']) && $package['type'] === 'drupal-module') {
             // If module was not reviewed yet.
             if (!$hasBeenQaEd) {
-                $this->say("Package $name:$packageVersion has not been reviewed by QA.");
+                $this->say("Package $packageName:$packageVersion has not been reviewed by QA.");
                 $this->whitelistComponentsFailed = true;
             }
 

--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -194,15 +194,8 @@ class ToolCommands extends AbstractCommands
             }
 
             if ($wasNotRejected) {
-                # This check will be removed in the future as the endpoint will
-                # be replacing the 'version' key with the 'conflict' key.
-                $moduleVersion = !empty($modules[$packageName]['version']) ? str_replace('8.x-', '', $modules[$packageName]['version']) : null;
-                if (!is_null($moduleVersion) && version_compare($packageVersion, $moduleVersion) === -1) {
-                    $this->say("Package $packageName:$packageVersion minimum allowed version is $moduleVersion.");
-                    $this->whitelistComponentsFailed = true;
-                }
-                # This will be the permanent check used to block certain
-                # versions of a package.
+                # Once all projects are using Toolkit >=4.1.0, the 'version' key
+                # may be removed from the endpoint: /api/v1/package-reviews.
                 $moduleConflict = !empty($modules[$packageName]['conflict']) ? $modules[$packageName]['conflict'] : null;
                 if (!is_null($moduleConflict) && Semver::satisfies($packageVersion, $moduleConflict)) {
                     $this->say("Package $packageName:$packageVersion does not meet version constraint: $moduleConflict.");

--- a/tests/fixtures/commands/drupal-settings-setup.yml
+++ b/tests/fixtures/commands/drupal-settings-setup.yml
@@ -24,7 +24,7 @@
         );
 
         // Location of the site configuration files, relative to the site root.
-        $config_directories['sync'] = '../config/sync';
+        $settings['config_sync_directory'] = '../config/sync';
 
         $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : 'YWJj';
         $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';
@@ -53,12 +53,12 @@
   expectations:
     - file: "build/sites/default/settings.php"
       contains: |
-        <?php
-        $foo = 'bar';
+          <?php
+          $foo = 'bar';
 
-        // Start Toolkit settings block.
+          // Start Toolkit settings block.
 
-        $databases['default']['default'] = array (
+          $databases['default']['default'] = array (
           'database' => getenv('DRUPAL_DATABASE_NAME'),
           'username' => getenv('DRUPAL_DATABASE_USERNAME'),
           'password' => getenv('DRUPAL_DATABASE_PASSWORD'),
@@ -67,25 +67,25 @@
           'port' => getenv('DRUPAL_DATABASE_PORT'),
           'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
           'driver' => 'mysql',
-        );
+          );
 
-        // Location of the site configuration files, relative to the site root.
-        $config_directories['sync'] = '../config/sync';
+          // Location of the site configuration files, relative to the site root.
+          $settings['config_sync_directory'] = '../config/sync';
 
-        $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : 'YWJj';
-        $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';
-        $settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') !== FALSE ? getenv('DRUPAL_FILE_TEMP_PATH') : '/tmp';
+          $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : 'YWJj';
+          $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';
+          $settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') !== FALSE ? getenv('DRUPAL_FILE_TEMP_PATH') : '/tmp';
 
-        $config['cas.settings']['server']['hostname'] = getenv('CAS_HOSTNAME');
-        $config['cas.settings']['server']['port'] = getenv('CAS_PORT');
+          $config['cas.settings']['server']['hostname'] = getenv('CAS_HOSTNAME');
+          $config['cas.settings']['server']['port'] = getenv('CAS_PORT');
 
-        // Load environment development override configuration, if available.
-        // Keep this code block at the end of this file to take full effect.
-        if (file_exists($app_root . '/' . $site_path . '/settings.override.php')) {
+          // Load environment development override configuration, if available.
+          // Keep this code block at the end of this file to take full effect.
+          if (file_exists($app_root . '/' . $site_path . '/settings.override.php')) {
           include $app_root . '/' . $site_path . '/settings.override.php';
-        }
+          }
 
-        // End Toolkit settings block.
+          // End Toolkit settings block.
       not_contains: ~
 
 - configuration: []
@@ -115,7 +115,7 @@
         );
 
         // Location of the site configuration files, relative to the site root.
-        $config_directories['sync'] = '../config/sync';
+        $settings['config_sync_directory'] = '../config/sync';
 
         $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : 'YWJj';
         $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';


### PR DESCRIPTION
- MULTISITE-22895	Do not print creds in toolkit:download-dump command.
- MULTISITE-22884	Command toolkit:build-dev should provide Drupal files folders
- MULTISITE-23016	Allow install-clone command to be extended by runner.yml.dist
- MULTISITE-23454	Refactor logic on minimum version checking to use version constraints
- MULTISITE-23618	Remove hard dependency on Guzzle
- MULTISITE-23745	Drupal 8.8 deprecated $config_directories['sync']