### PR TITLE
DQA-2534: Better output for lint-yaml.

### DIFF
--- a/src/TaskRunner/Commands/TestsCommands.php
+++ b/src/TaskRunner/Commands/TestsCommands.php
@@ -329,7 +329,9 @@ class TestsCommands extends AbstractCommands implements FilesystemAwareInterface
 
         // Prepare arguments.
         $arg = implode(' ', $files);
-        $task = $this->taskExec("./vendor/bin/yaml-lint -q $arg");
+        $task = $this->taskExec("./vendor/bin/yaml-lint -q $arg")
+            ->printMetadata(false);
+
         return $this->collectionBuilder()->addTaskList([$task]);
     }
 


### PR DESCRIPTION
Will output something like:
```
> ./vendor/bin/run toolkit:lint-yaml
➜  Pattern: *.yml, *.yaml, *.yml.dist, *.yaml.dist
➜  Include: lib/, config/
➜  Exclude: vendor/, web/, node_modules/
➜  Found 775 files to lint.
yaml-lint 1.1.4: parsing ./example.yml [ ERROR ]

You cannot define a sequence item when in a mapping at line 6 (near "- nfsmount:${PWD}").

 [Exec]  Exit code 1
```