### PR TITLE
Allow platform-dev usage of forks to debug.

### DIFF
--- a/build.default.props
+++ b/build.default.props
@@ -289,6 +289,7 @@ platform.package.db.cache.ttl = 30
 platform.package.provider = git-hub
 platform.package.provider.token = # TODO: Github API limit.
 platform.package.repository = ec-europa/platform-dev
+platform.package.download.filename = platform-dev-${platform.package.version.current}.tar.gz
 platform.package.download.location = https://github.com/${platform.package.repository}/releases/download/${platform.package.version.current}
 platform.package.download.prerelease = false
 platform.package.version = 2.5

--- a/includes/phing/build/main/project.xml
+++ b/includes/phing/build/main/project.xml
@@ -563,13 +563,12 @@
         <property file="${project.tmp.dir}/build.version.props" logoutput="${logoutput}" override="true" />
         <mkdir dir="${share.path.platform.packages.deploy}" />
         <phingcall target="package-download-unpack">
-            <property name="package-name" value="platform-dev-${platform.package.version.current}.tar.gz" />
+            <property name="package-name" value="${platform.package.download.filename}" />
             <property name="package-cache-location" value="${share.path.platform.packages.deploy}" />
             <property name="package-download-location" value="${platform.package.download.location}" />
             <property name="package-extract-location" value="${build.platform.dir}" />
         </phingcall>
     </target>
-
     <target name="project-platform-set-htaccess" hidden="true" description="Append htaccess config to root .htaccess.">
         <if>
             <istrue value="${build.platform.htaccess.append.text}" />
@@ -593,7 +592,7 @@
         hidden="true">
         <!-- Delete of saved versions to force refresh -->
         <exec command='rm -rf ${project.tmp.dir}/build.version.props' outputProperty="log" checkreturn="true" />
-        <platformversions packageVersion="${platform.package.version}" preRelease="${platform.package.download.prerelease}" />
+        <platformversions packageVersion="${platform.package.version}" preRelease="${platform.package.download.prerelease}" packageRepository="${platform.package.repository}"/>
         <echoproperties regex="~^platform\.package\.version~" destfile="${project.tmp.dir}/build.version.props" />
     </target>
 

--- a/includes/phing/props/main.props
+++ b/includes/phing/props/main.props
@@ -106,6 +106,7 @@ platform.package.db.cache.ttl = 30
 platform.package.provider = git-hub
 platform.package.provider.token = # TODO: Github API limit.
 platform.package.repository = ec-europa/platform-dev
+platform.package.download.filename = platform-dev-${platform.package.version.current}.tar.gz
 platform.package.download.location = https://github.com/${platform.package.repository}/releases/download/${platform.package.version.current}
 platform.package.download.prerelease = false
 platform.package.version = 2.5

--- a/includes/phing/src/Tasks/PlatformVersionsTask.php
+++ b/includes/phing/src/Tasks/PlatformVersionsTask.php
@@ -39,6 +39,13 @@ class PlatformVersionsTask extends \Task
     private $_majorVersion = '';
 
     /**
+     * The repository specified in the project props.
+     *
+     * @var string
+     */
+    private $_packageRepository = '';
+
+    /**
      * The version specified in the project props.
      *
      * @var string
@@ -83,7 +90,7 @@ class PlatformVersionsTask extends \Task
         );
 
         // Get latest version of Platform.
-        $resp = $this->callGithubReleases('https://api.github.com/repos/ec-europa/platform-dev/releases/latest');
+        $resp = $this->callGithubReleases('https://api.github.com/repos/' . $this->_packageRepository . '/releases/latest');
         $latest_version = $resp->tag_name;
 
         // Check if user has provided the latest version.
@@ -92,7 +99,7 @@ class PlatformVersionsTask extends \Task
         }
         else {
             // Get latest version of NE Platform.
-            $resp = $this->callGithubReleases('https://api.github.com/repos/ec-europa/platform-dev/releases');
+            $resp = $this->callGithubReleases('https://api.github.com/repos/' . $this->_packageRepository . '/releases');
             foreach($resp as $object) {
                 // Skip drafts and prereleases.
                 if ($object->draft == false && $object->prerelease == false) {
@@ -176,6 +183,18 @@ class PlatformVersionsTask extends \Task
             }
         }
     }//end checkRequirements()
+
+    /**
+     * Sets the current package repository.
+     *
+     * @param string $packageRepository The current project repository.
+     *
+     * @return void
+     */
+    public function setPackageRepository($packageRepository)
+    {
+        $this->_packageRepository = $packageRepository;
+    }//end setPackageRepository()
 
     /**
      * Sets the current package version.


### PR DESCRIPTION
After doing a fork of ec-europa/platform-dev and making a release in my fork. Here is my `build.develop.props` to test this non official release:


Adding to my `build.develop.props`:
```
platform.package.repository = julien-/platform-dev
platform.package.download.location = https://github.com/${platform.package.repository}/archive/refs/tags
platform.package.download.filename = ${platform.package.version.current}.tar.gz
```
It allows to not wait official releases from ec-europa/platform-dev and test a branch if you set to TRUE pre-release usage.


______

To test this PR, I added to my `composer.json`:
```
    "repositories": [
        {
            "type": "package",
            "package": {
                "name": "ec-europa/toolkit",
                "version": "3.0",
                "source": {
                    "type": "git",
                    "url": "https://github.com/julien-/toolkit.git",
                    "reference": "7e017c04893bf50d30f8dd1e7fd3769cebb38bba"
                },
                "dist": {
                    "type": "zip",
                    "url": "https://github.com/julien-/toolkit/archive/7e017c04893bf50d30f8dd1e7fd3769cebb38bba",
                    "reference": "7e017c04893bf50d30f8dd1e7fd3769cebb38bba",
                    "shasum": ""
                }
            }
        }
    ],
```
And do a `composer update`

