### PR TITLE
DQA-0: Improve output toolkit:component-check.

### DIFF
--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -6,6 +6,7 @@ namespace EcEuropa\Toolkit\TaskRunner\Commands;
 
 use Composer\Semver\Semver;
 use OpenEuropa\TaskRunner\Tasks\ProcessConfigFile\loadTasks;
+use Robo\Contract\VerbosityThresholdInterface;
 use Symfony\Component\Console\Input\InputOption;
 use OpenEuropa\TaskRunner\Commands\AbstractCommands;
 use Symfony\Component\Yaml\Yaml;
@@ -399,15 +400,9 @@ class ToolCommands extends AbstractCommands
      */
     protected function componentInsecure()
     {
-        // Build task collection.
-        $collection = $this->collectionBuilder();
-        $result = $collection->taskExecStack()
-            ->exec('drush pm:security --format=json')
-            ->silent(true)
-            ->printOutput(false)
-            ->storeState('insecure')
-            ->run()
-            ->getMessage();
+        $result = $this->taskExec('drush pm:security --format=json')
+            ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_DEBUG)
+            ->run()->getMessage();
 
         if (strpos(trim((string) $result), 'There are no outstanding security') !== false) {
             $this->say("There are no outstanding security updates.");
@@ -449,14 +444,9 @@ class ToolCommands extends AbstractCommands
      */
     protected function componentOutdated()
     {
-        $collection = $this->collectionBuilder();
-        $result = $collection->taskExecStack()
-            ->exec('composer outdated --direct --minor-only --format=json')
-            ->printOutput(false)
-            ->storeState('outdated')
-            ->silent(true)
-            ->run()
-            ->getMessage();
+        $result = $this->taskExec('composer outdated --direct --minor-only --format=json')
+            ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_DEBUG)
+            ->run()->getMessage();
 
         $outdatedPackages = json_decode($result, true);
 


### PR DESCRIPTION
Clean a bit the output.
Here we can find a nice explanation on the output logic https://github.com/consolidation/Robo/issues/629#issuecomment-341940337
Looks like the following:
```
> dcwebr toolkit:component-check   

Checking Mandatory components.
==============================

➜  Mandatory components check passed.

Checking Recommended components.
================================

➜  Package drupal/seckit is recommended but is not present on the project.
➜  This step is in reporting mode, skipping.

Checking Insecure components.
=============================

➜  Package drupal/remote_stream_wrapper have a security update, please update to a safe version.

Checking Outdated components.
=============================

➜  Package digit/digit_qa with version installed 1.0.1 is outdated, please update to last version - 1.0.2
➜  Package digit/qa_core with version installed 1.0.2 is outdated, please update to last version - 1.0.4
➜  Package drupal/gin with version installed 3.0.0-alpha33 is outdated, please update to last version - 3.0.0-beta2
➜  Package drupal/gin_login with version installed 1.0.0-rc7 is outdated, please update to last version - 1.2.0
➜  Package drupal/gin_toolbar with version installed 1.0.0-beta14 is outdated, please update to last version - 1.0.0-beta22
➜  Package drupal/remote_stream_wrapper with version installed 1.4.0 is outdated, please update to last version - 1.5.0
➜  Package webmozart/path-util with version installed 2.3.0 is outdated, please update to last version - 2.3.0

Checking evaluation status components.
======================================

➜  Evaluation module check passed.

Checking dev components.
========================

➜  Package furf/jquery-ui-touch-punch:dev-master cannot be used in dev version.

Results:
========

➜  Mandatory module check passed.
➜  Recommended module check passed. (report only)
➜  Insecure module check failed.
➜  Outdated module check failed. (Skipping)
➜  Dev module check failed.
➜  Evaluation module check passed.


 [ERROR] Failed the components check, please verify the report and update the project.
         See the list of packages at https://webgate.ec.europa.eu/fpfis/qa/package-reviews.


 NOTE: It is possible to bypass the insecure and outdated check by providing a token in the commit message.
 The available tokens are:
     - [SKIP-OUTDATED]
     - [SKIP-INSECURE]
```