### PR TITLE
DQA-4075: [TOOLKIT] Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "cweagans/composer-patches": "^1.4 || ^1.7",
         "drush/drush": "^9.7.1 || ^10.0.0 || ^11.0.4",
         "ec-europa/qa-automation": "^8.1.2",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.0",
         "j13k/yaml-lint": "^1.1",
         "openeuropa/task-runner": "^2.0@alpha",
         "php-parallel-lint/php-parallel-lint": "^1.3",


### PR DESCRIPTION
Only one outdated package 
```
> composer outdated -D
Info from https://repo.packagist.org: #StandWithUkraine
Color legend:
- patch or minor release available - update recommended
- major release available - update possible
guzzlehttp/guzzle 6.5.5 7.4.2 Guzzle is a PHP HTTP client library
```