### PR TITLE
DQA-5323: Avoid backlash bypass in opts-review.

### DIFF
--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -841,6 +841,7 @@ class ToolCommands extends AbstractCommands
 
             foreach ($parseOptsFile['upgrade_commands'] as $key => $commands) {
                 foreach ($commands as $command) {
+                    $command = str_replace('\\', '', $command);
                     foreach ($forbiddenCommands as $forbiddenCommand) {
                         if ($key == 'default') {
                             $parsedCommand = explode(" ", $command);


### PR DESCRIPTION
PR with initial approach to avoid backslash being used to bypass .opts.yml file review in toolkit:opts-review.
[DQA-5325](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/DQA-5323)