### PR TITLE
DROPSEC-2909: Prevent concatenation bypass of forbidden commands in opts-review.

### DIFF
--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -844,14 +844,14 @@ class ToolCommands extends AbstractCommands
                     $command = str_replace('\\', '', $command);
                     foreach ($forbiddenCommands as $forbiddenCommand) {
                         if ($key == 'default') {
-                            $parsedCommand = explode(" ", $command);
+                            $parsedCommand = preg_split("/[\s;&|]/", $command, 0, PREG_SPLIT_NO_EMPTY);;
                             if (in_array($forbiddenCommand, $parsedCommand)) {
                                 $this->say("The command '$command' is not allowed. Please remove it from 'upgrade_commands' section.");
                                 $reviewOk = false;
                             }
                         } else {
                             foreach ($command as $env => $subCommand) {
-                                $parsedCommand = explode(' ', $subCommand);
+                                $parsedCommand = preg_split("/[\s;&|]/", $subCommand, 0, PREG_SPLIT_NO_EMPTY);
                                 if (in_array($forbiddenCommand, $parsedCommand)) {
                                     $this->say("The command '$subCommand' is not allowed. Please remove it from 'upgrade_commands' section.");
                                     $reviewOk = false;

--- a/src/TaskRunner/Commands/ToolCommands.php
+++ b/src/TaskRunner/Commands/ToolCommands.php
@@ -844,7 +844,7 @@ class ToolCommands extends AbstractCommands
                     $command = str_replace('\\', '', $command);
                     foreach ($forbiddenCommands as $forbiddenCommand) {
                         if ($key == 'default') {
-                            $parsedCommand = preg_split("/[\s;&|]/", $command, 0, PREG_SPLIT_NO_EMPTY);;
+                            $parsedCommand = preg_split("/[\s;&|]/", $command, 0, PREG_SPLIT_NO_EMPTY);
                             if (in_array($forbiddenCommand, $parsedCommand)) {
                                 $this->say("The command '$command' is not allowed. Please remove it from 'upgrade_commands' section.");
                                 $reviewOk = false;


### PR DESCRIPTION
This prevents the following 4 ways (concatenate with `;`, `&`, `|` or `&&`) of bypassing the opts-review check of forbidden commands:
```
    - ./vendor/bin/drush user-login;echo
    - ./vendor/bin/drush user-login&echo
    - ./vendor/bin/drush user-login|echo
    - ./vendor/bin/drush user-login&&echo
    - echo;curl https://www.example.com
    - echo&curl https://www.example.com
    - echo|curl https://www.example.com
    - echo&&curl https://www.example.com
```

Discussion in: https://citnet.tech.ec.europa.eu/CITnet/jira/browse/DROPSEC-2909

Also, I assume that this, together with https://github.com/ec-europa/toolkit/pull/571 will, at some point, be ported to `release/9.x` as well.