### PR TITLE
DQA-5962: Delayed task list to allow command hooks to run before

### DIFF
--- a/src/TaskRunner/Commands/ConfigurationCommands.php
+++ b/src/TaskRunner/Commands/ConfigurationCommands.php
@@ -21,10 +21,8 @@ class ConfigurationCommands extends AbstractCommands
     public function execute()
     {
         $name = $this->input()->getArgument('command');
-        /* @var \Consolidation\AnnotatedCommand\AnnotatedCommand $command */
-        $command = Robo::application()->get($name);
-        $commandDefinition = $this->getConfig()->get("commands.$name");
-        $tasks = $commandDefinition['tasks'] ?? $commandDefinition;
+        $command = $this->getConfig()->get("commands.$name");
+        $tasks = $command['tasks'] ?? $command;
         return $this->taskExecute($tasks);
     }
 

--- a/src/TaskRunner/Commands/ConfigurationCommands.php
+++ b/src/TaskRunner/Commands/ConfigurationCommands.php
@@ -23,7 +23,8 @@ class ConfigurationCommands extends AbstractCommands
         $name = $this->input()->getArgument('command');
         /* @var \Consolidation\AnnotatedCommand\AnnotatedCommand $command */
         $command = Robo::application()->get($name);
-        $tasks = $command->getAnnotationData()['tasks'];
+        $commandDefinition = $this->getConfig()->get("commands.$name");
+        $tasks = $commandDefinition['tasks'] ?? $commandDefinition;
         return $this->taskExecute($tasks);
     }
 

--- a/src/TaskRunner/Runner.php
+++ b/src/TaskRunner/Runner.php
@@ -307,7 +307,6 @@ class Runner
             }
 
             $commandInfo = $commandFactory->createCommandInfo($commandClass, 'execute');
-            $commandInfo->addAnnotation('tasks', $tasks['tasks'] ?? $tasks);
 
             $command = $commandFactory->createCommand($commandInfo, $commandClass)
                 ->setName($name);


### PR DESCRIPTION
## Problem

Let's take this configuration command:

```yaml
commands:
  foo:
    tasks:
      - task: exec
        command: mkdir ${some.dynamic.var}
```

And let's say that `${some.dynamic.var}` is not known before, in order to be stored in a config YAML file. Instead, this var is computed in the following annotated command hook:

```php
/**
 * @hook pre-init *
 */ 
public function provideVar(): void {
  ...
  $this->getConfig()->set('some.dynamic.var', $dynamicComputedValue);
}
```

With the current code, the list of `foo` command tasks is passed to configuration command annotation too early (in `Runner::registerConfigurationCommands()`), before hooks are running. So, this config alter is not taken into account.

The command will output an error.

## Proposal

Fetch the command tasks list at command execution, so that annotated commands hooks got the chance to manipulate the configuration.
