### PR TITLE
DQA-9954: Improve regex pattern unsupported checks readonly comment

### DIFF
--- a/src/TaskRunner/Commands/ComponentCheckCommands.php
+++ b/src/TaskRunner/Commands/ComponentCheckCommands.php
@@ -1015,7 +1015,7 @@ class ComponentCheckCommands extends AbstractCommands
             if (file_exists($settings)) {
                 $content = file_get_contents($settings);
                 if (str_contains($content, 'config_readonly')) {
-                    file_put_contents($settings, preg_replace('#(^\$settings\[["|\']config_readonly)#m', "//$1", $content));
+                    file_put_contents($settings, preg_replace('#(^\s*\$settings\[["\']config_readonly["\']\])#m', "//$1", $content));
                     $this->disabledConfigReadonly = true;
                 }
             }
@@ -1033,7 +1033,7 @@ class ComponentCheckCommands extends AbstractCommands
         $config = $this->getConfig();
         $settings = $config->get('drupal.root') . '/sites/' . $config->get('drupal.site.sites_subdir') . '/settings.php';
         $content = file_get_contents($settings);
-        file_put_contents($settings, preg_replace('#^//(\$settings\[["|\']config_readonly)#m', "$1", $content));
+        file_put_contents($settings, preg_replace('#^//(\s*\$settings\[["\']config_readonly["\']\])#m', "$1", $content));
     }
 
 }


### PR DESCRIPTION
This is a PR which tries tor improve the regular expression used in toolkit in order to comment the line from settings.php which sets to TRUE the module config_readonly while running toolkit:component-checks and especially unsupported check.