### PR TITLE
Extra informations about copy and watch ecl commands.

### DIFF
--- a/config/runner/toolkit.yml
+++ b/config/runner/toolkit.yml
@@ -112,7 +112,7 @@ toolkit:
     npm:
       theme-task-runner: ecl-builder
       packages: '@ecl/builder @ecl/preset-ec @ecl/preset-eu @ecl/preset-reset'
-      ecl-command: 'styles scripts'
+      ecl-command: 'styles scripts copy'
   scss:
     validate: 'false'
   invalid-versions:

--- a/docs/guide/building-assets.rst
+++ b/docs/guide/building-assets.rst
@@ -30,7 +30,7 @@ like shown below:
       npm:
         theme-task-runner: ecl-builder gulp
         packages: '@ecl/builder pikaday moment gulp gulp-concat gulp-sass gulp-clean-css gulp-minify'
-        ecl-command: 'styles scripts'
+        ecl-command: 'styles scripts copy'
 
 Command to run:
 
@@ -58,9 +58,9 @@ Build theme assets (ecl-builder)
 
 By default Toolkit compiles the Css and Js files, defined in the configuration file
 'ecl-builder.config.js' as entry and destination paths.
-The ecl-builder command used for this action is 'styles'. This the default command.
+The ecl-builder commands used by default are related to 'ecl-command' in your runner.yml.dist file.
 
-To use other command listed on 'ecl-builder' options an additional parameter can be provided:
+To use a specific command listed on 'ecl-builder' options an additional parameter can be provided:
 '--ecl-command'
 
 .. code-block::

--- a/resources/assets/ecl-builder.config.js
+++ b/resources/assets/ecl-builder.config.js
@@ -27,12 +27,50 @@ module.exports = {
     // Copy files from src to dest
     copy: [
         {
-            from: path.resolve(__dirname, 'src/fonts'),
-            to: path.resolve(__dirname, 'dist/fonts'),
-        },
-        {
-            from: path.resolve(__dirname, 'src/images'),
-            to: path.resolve(__dirname, 'dist/images'),
+            from: path.resolve(__dirname, 'src/assets'),
+            to: path.resolve(__dirname, 'dist/assets'),
         },
     ],
+    // Watcher
+    watch: {
+        handlers: [{
+                pattern: `./src/*.scss`,
+                events: [{
+                    on: 'change',
+                    name: 'watch styles',
+                    command: './node_modules/.bin/ecl-builder styles',
+                    message: 'Styles updated',
+                    reload: 'dist/*.css'
+                }, ],
+            },
+            {
+                pattern: `./src/*.js`,
+                events: [{
+                    on: 'change',
+                    name: 'watch scripts',
+                    command: './node_modules/.bin/ecl-builder scripts',
+                    message: 'Scripts updated',
+                    reload: 'dist/*.js'
+                }, ],
+            },
+            {
+                pattern: `./assets/**/*.*`,
+                events: [{
+                        on: 'change',
+                        name: 'watch copy',
+                        command: './node_modules/.bin/ecl-builder copy',
+                        message: 'Updated assets',
+                        reload: 'dist/assets/*'
+                    },
+                    {
+                        on: 'add',
+                        name: 'watch copy',
+                        command: './node_modules/.bin/ecl-builder copy',
+                        message: 'New assets added',
+                        reload: 'dist/assets/*'
+                    },
+                ],
+            }
+        ]
+    }
 };

--- a/tests/fixtures/commands/build.yml
+++ b/tests/fixtures/commands/build.yml
@@ -187,3 +187,6 @@
         [Simulator] Simulating Exec('./node_modules/.bin/ecl-builder scripts')
           ->dir('/test/toolkit/tests/sandbox/BuildCommandsTest/code/theme')
         [Simulator] Running ./node_modules/.bin/ecl-builder scripts in /test/toolkit/tests/sandbox/BuildCommandsTest/code/theme
+        [Simulator] Simulating Exec('./node_modules/.bin/ecl-builder copy')
+          ->dir('/test/toolkit/tests/sandbox/BuildCommandsTest/code/theme')
+        [Simulator] Running ./node_modules/.bin/ecl-builder copy in /test/toolkit/tests/sandbox/BuildCommandsTest/code/theme


### PR DESCRIPTION
Currently, there is no indication about the `watch` command & config.
You have to dig in the source code of toolkit and ecl repos to find about it.

**Related to that:**
https://github.com/search?q=repo%3Aec-europa%2Feuropa-component-library%20watch&type=code
https://browsersync.io/docs/api#api-watch

And some oversight about the `copy` command and the default behavior of build-assets without any ecl command specified.

So, here some update proposal to help others like me at the start.