### PR TITLE
DQA-13313: Pass DB prefix to drupal:install command

### DIFF
--- a/config/commands/drupal.yml
+++ b/config/commands/drupal.yml
@@ -19,6 +19,7 @@ command:
         database-name: ${drupal.database.name}
         database-user: ${drupal.database.user}
         database-password: ${drupal.database.password}
+        database-prefix: ${drupal.database.prefix}
         existing-config: ${drupal.site.existing_config}
         skip-permissions-setup: ${drupal.site.skip_permissions_setup}
     settings-setup:

--- a/src/TaskRunner/Commands/DrupalCommands.php
+++ b/src/TaskRunner/Commands/DrupalCommands.php
@@ -261,6 +261,7 @@ class DrupalCommands extends AbstractCommands
      * @option database-name          Database name.
      * @option database-user          Database username.
      * @option database-password      Database password.
+     * @option database-prefix        Database prefix.
      * @option sites-subdir           Sites subdirectory.
      * @option site-update            Whether to enable the update module or not during installation.
      * @option existing-config        Whether existing config should be imported during installation.
@@ -288,6 +289,7 @@ class DrupalCommands extends AbstractCommands
         'database-host' => InputOption::VALUE_REQUIRED,
         'database-port' => InputOption::VALUE_REQUIRED,
         'database-name' => InputOption::VALUE_REQUIRED,
+        'database-prefix' => InputOption::VALUE_REQUIRED,
         'sites-subdir' => InputOption::VALUE_REQUIRED,
         'config-dir' => InputOption::VALUE_REQUIRED,
         'site-update' => InputOption::VALUE_NONE,
@@ -315,6 +317,10 @@ class DrupalCommands extends AbstractCommands
             'account-pass' => $options['account-password'],
             'sites-subdir' => $options['sites-subdir'],
         ];
+
+        if (!empty($options['database-prefix'])) {
+            $execOptions['db-prefix'] = $options['database-prefix'];
+        }
 
         if (!empty($dbUrl = $this->getConfig()->get('drupal.site.generate_db_url'))) {
             $dbArray = [


### PR DESCRIPTION
If a prefix is configured either in `runner.yml.dist` or in the environment variable `DRUPAL_DATABASE_PREFIX` it is being ignored in `run toolkit:site-install`. 

So all the tables will be created without the prefix, but then `settings.php` will read the environment variable and the commands after the installation will fail. 

To resolve this issue, the configuration should be passed to the drush command.