### PR TITLE
DQA-13626: Improve database default values

### DIFF
--- a/src/TaskRunner/Commands/DrupalCommands.php
+++ b/src/TaskRunner/Commands/DrupalCommands.php
@@ -636,9 +636,9 @@ class DrupalCommands extends AbstractCommands
   'database' => getenv('DRUPAL_DATABASE_NAME'),
   'username' => getenv('DRUPAL_DATABASE_USERNAME'),
   'password' => getenv('DRUPAL_DATABASE_PASSWORD'),
-  'prefix' => getenv('DRUPAL_DATABASE_PREFIX'),
+  'prefix' => getenv('DRUPAL_DATABASE_PREFIX') ?: '',
   'host' => getenv('DRUPAL_DATABASE_HOST'),
-  'port' => getenv('DRUPAL_DATABASE_PORT'),
+  'port' => getenv('DRUPAL_DATABASE_PORT') ?: 3306,
   'namespace' => getenv('DRUPAL_DATABASE_DRIVER') !== FALSE ? 'Drupal\\\\Core\\\\Database\\\\Driver\\\\' . getenv('DRUPAL_DATABASE_DRIVER') : 'Drupal\\\\Core\\\\Database\\\\Driver\\\\mysql',
   'driver' => getenv('DRUPAL_DATABASE_DRIVER') !== FALSE ? getenv('DRUPAL_DATABASE_DRIVER') : 'mysql',
   'init_commands' => array (
@@ -649,9 +649,9 @@ class DrupalCommands extends AbstractCommands
 // Location of the site configuration files, relative to the site root.
 \$settings['config_sync_directory'] = '../config/sync';
 
-\$settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : '$hashSalt';
-\$settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';
-\$settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') !== FALSE ? getenv('DRUPAL_FILE_TEMP_PATH') : '/tmp';
+\$settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') ?: '$hashSalt';
+\$settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') ?: 'sites/default/private_files';
+\$settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') ?: '/tmp';
 
 // Reverse proxy.
 if (filter_var(getenv('DRUPAL_REVERSE_PROXY_ENABLE'), FILTER_VALIDATE_BOOLEAN)) {

--- a/tests/fixtures/commands/drupal-settings-setup.yml
+++ b/tests/fixtures/commands/drupal-settings-setup.yml
@@ -22,9 +22,9 @@
           'database' => getenv('DRUPAL_DATABASE_NAME'),
           'username' => getenv('DRUPAL_DATABASE_USERNAME'),
           'password' => getenv('DRUPAL_DATABASE_PASSWORD'),
-          'prefix' => getenv('DRUPAL_DATABASE_PREFIX'),
+          'prefix' => getenv('DRUPAL_DATABASE_PREFIX') ?: '',
           'host' => getenv('DRUPAL_DATABASE_HOST'),
-          'port' => getenv('DRUPAL_DATABASE_PORT'),
+          'port' => getenv('DRUPAL_DATABASE_PORT') ?: 3306,
           'namespace' => getenv('DRUPAL_DATABASE_DRIVER') !== FALSE ? 'Drupal\\Core\\Database\\Driver\\' . getenv('DRUPAL_DATABASE_DRIVER') : 'Drupal\\Core\\Database\\Driver\\mysql',
           'driver' => getenv('DRUPAL_DATABASE_DRIVER') !== FALSE ? getenv('DRUPAL_DATABASE_DRIVER') : 'mysql',
           'init_commands' => array (
@@ -35,9 +35,9 @@
         // Location of the site configuration files, relative to the site root.
         $settings['config_sync_directory'] = '../config/sync';
 
-        $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : 'YWJj';
-        $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';
-        $settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') !== FALSE ? getenv('DRUPAL_FILE_TEMP_PATH') : '/tmp';
+        $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') ?: 'YWJj';
+        $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') ?: 'sites/default/private_files';
+        $settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') ?: '/tmp';
 
         // Reverse proxy.
         if (filter_var(getenv('DRUPAL_REVERSE_PROXY_ENABLE'), FILTER_VALIDATE_BOOLEAN)) {
@@ -86,9 +86,9 @@
           'database' => getenv('DRUPAL_DATABASE_NAME'),
           'username' => getenv('DRUPAL_DATABASE_USERNAME'),
           'password' => getenv('DRUPAL_DATABASE_PASSWORD'),
-          'prefix' => getenv('DRUPAL_DATABASE_PREFIX'),
+          'prefix' => getenv('DRUPAL_DATABASE_PREFIX') ?: '',
           'host' => getenv('DRUPAL_DATABASE_HOST'),
-          'port' => getenv('DRUPAL_DATABASE_PORT'),
+          'port' => getenv('DRUPAL_DATABASE_PORT') ?: 3306,
           'namespace' => getenv('DRUPAL_DATABASE_DRIVER') !== FALSE ? 'Drupal\\Core\\Database\\Driver\\' . getenv('DRUPAL_DATABASE_DRIVER') : 'Drupal\\Core\\Database\\Driver\\mysql',
           'driver' => getenv('DRUPAL_DATABASE_DRIVER') !== FALSE ? getenv('DRUPAL_DATABASE_DRIVER') : 'mysql',
           'init_commands' => array (
@@ -99,9 +99,9 @@
         // Location of the site configuration files, relative to the site root.
         $settings['config_sync_directory'] = '../config/sync';
 
-        $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : 'YWJj';
-        $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';
-        $settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') !== FALSE ? getenv('DRUPAL_FILE_TEMP_PATH') : '/tmp';
+        $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') ?: 'YWJj';
+        $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') ?: 'sites/default/private_files';
+        $settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') ?: '/tmp';
 
         // Reverse proxy.
         if (filter_var(getenv('DRUPAL_REVERSE_PROXY_ENABLE'), FILTER_VALIDATE_BOOLEAN)) {
@@ -150,9 +150,9 @@
           'database' => getenv('DRUPAL_DATABASE_NAME'),
           'username' => getenv('DRUPAL_DATABASE_USERNAME'),
           'password' => getenv('DRUPAL_DATABASE_PASSWORD'),
-          'prefix' => getenv('DRUPAL_DATABASE_PREFIX'),
+          'prefix' => getenv('DRUPAL_DATABASE_PREFIX') ?: '',
           'host' => getenv('DRUPAL_DATABASE_HOST'),
-          'port' => getenv('DRUPAL_DATABASE_PORT'),
+          'port' => getenv('DRUPAL_DATABASE_PORT') ?: 3306,
           'namespace' => getenv('DRUPAL_DATABASE_DRIVER') !== FALSE ? 'Drupal\\Core\\Database\\Driver\\' . getenv('DRUPAL_DATABASE_DRIVER') : 'Drupal\\Core\\Database\\Driver\\mysql',
           'driver' => getenv('DRUPAL_DATABASE_DRIVER') !== FALSE ? getenv('DRUPAL_DATABASE_DRIVER') : 'mysql',
           'init_commands' => array (
@@ -163,9 +163,9 @@
         // Location of the site configuration files, relative to the site root.
         $settings['config_sync_directory'] = '../config/sync';
 
-        $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') !== FALSE ? getenv('DRUPAL_HASH_SALT') : 'YWJj';
-        $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') !== FALSE ? getenv('DRUPAL_PRIVATE_FILE_SYSTEM') : 'sites/default/private_files';
-        $settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') !== FALSE ? getenv('DRUPAL_FILE_TEMP_PATH') : '/tmp';
+        $settings['hash_salt'] = getenv('DRUPAL_HASH_SALT') ?: 'YWJj';
+        $settings['file_private_path'] =  getenv('DRUPAL_PRIVATE_FILE_SYSTEM') ?: 'sites/default/private_files';
+        $settings['file_temp_path'] = getenv('DRUPAL_FILE_TEMP_PATH') ?: '/tmp';
 
         // Reverse proxy.
         if (filter_var(getenv('DRUPAL_REVERSE_PROXY_ENABLE'), FILTER_VALIDATE_BOOLEAN)) {


### PR DESCRIPTION
I'm proposing some changes in how the default value of the environment variables are handled:

- `DRUPAL_DATABASE_PORT`: I think 99% of Drupal sites are using MySQL, even the default driver, one line below, is set to `mysql`, so I think if the port is not defined or provided as empty, the default value should be the default port from MySQL.
- `DRUPAL_DATABASE_PREFIX`: I think 99% of Drupal sites are not using a prefix, so the environment variable do not need to be provided and the correct value should be an empty string, but with the current implementation, the default value is `false`.
- `DRUPAL_HASH_SALT`: The current implementation in only taking the default value if the environment variable is not defined, but if an empty string is provided, the site will crash.
- `DRUPAL_PRIVATE_FILE_SYSTEM` and `DRUPAL_FILE_TEMP_PATH`: same as the previous, if provided as an empty string, an empty string will be used, instead of the default value.