### PR TITLE
DQA-13914: Validate SHA256 of gitleaks binary after download

### DIFF
--- a/config/commands/gitleaks.yml
+++ b/config/commands/gitleaks.yml
@@ -3,5 +3,6 @@ command:
     run-gitleaks:
       options:
         tag: ${gitleaks.tag}
+        sha256: ${gitleaks.sha256}
         os: ${gitleaks.os}
         options: ${gitleaks.options}

--- a/config/runner/gitleaks.yml
+++ b/config/runner/gitleaks.yml
@@ -1,5 +1,6 @@
 gitleaks:
   repo: https://github.com/gitleaks/gitleaks
   tag: 8.27.2
+  sha256: 141c3b2dede46d8b3a53b47116da756bd223decc0374797559a6b50ecba5590c
   os: linux_x64
   options: '--no-banner -v --no-git --follow-symlinks'

--- a/src/TaskRunner/Commands/GitleaksCommands.php
+++ b/src/TaskRunner/Commands/GitleaksCommands.php
@@ -38,6 +38,7 @@ class GitleaksCommands extends AbstractCommands
      * @command toolkit:run-gitleaks
      *
      * @option tag     The release tag of Gitleaks.
+     * @option sha256  SHA-256 checksum of the release archive.
      * @option os      The current OS version.
      * @option options The options to use when executing gitleaks command.
      *
@@ -48,12 +49,13 @@ class GitleaksCommands extends AbstractCommands
      */
     public function toolkitRunGitleaks(ConsoleIO $io, array $options = [
         'tag' => InputOption::VALUE_REQUIRED,
+        'sha256' => InputOption::VALUE_REQUIRED,
         'os' => InputOption::VALUE_REQUIRED,
         'options' => InputOption::VALUE_REQUIRED,
     ])
     {
         $repo = $this->getConfig()->get('gitleaks.repo');
-        if (!$this->download($repo, $options['tag'], $options['os'])) {
+        if (!$this->download($repo, $options['tag'], $options['os'], $options['sha256'])) {
             $io->error('Fail to download Gitleaks binary.');
             return ResultData::EXITCODE_ERROR;
         }
@@ -85,8 +87,10 @@ class GitleaksCommands extends AbstractCommands
      *   The release tag to download.
      * @param string $os
      *   The Operating system to use to download.
+     * @param string $sha256
+     *   Expected SHA-256 checksum of the downloaded archive.
      */
-    private function download(string $repo, string $tag, string $os): bool
+    private function download(string $repo, string $tag, string $os, string $sha256): bool
     {
         $link = "$repo/releases/download/v$tag/gitleaks_{$tag}_$os.tar.gz";
         $this->writeln("Downloading from $link");
@@ -95,6 +99,10 @@ class GitleaksCommands extends AbstractCommands
         }
         $tmp = 'gitleaks_tmp';
         if ($file = file_get_contents($link)) {
+            if (!$this->isChecksumValid($file, $sha256)) {
+                $this->writeln('Invalid SHA-256 checksum for downloaded Gitleaks archive.');
+                return false;
+            }
             if (!file_exists($tmp)) {
                 $this->_mkdir($tmp);
             }
@@ -110,6 +118,19 @@ class GitleaksCommands extends AbstractCommands
             }
         }
         return false;
+    }
+
+    /**
+     * Validate the archive SHA-256 checksum.
+     *
+     * @param string $file
+     *   Archive contents.
+     * @param string $sha256
+     *   Expected SHA-256 checksum.
+     */
+    private function isChecksumValid(string $file, string $sha256): bool
+    {
+        return hash_equals(strtolower($sha256), strtolower(hash('sha256', $file)));
     }
 
 }

--- a/tests/Unit/GitleaksCommandsChecksumTest.php
+++ b/tests/Unit/GitleaksCommandsChecksumTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EcEuropa\Toolkit\Tests\Unit;
+
+use EcEuropa\Toolkit\TaskRunner\Commands\GitleaksCommands;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for Gitleaks checksum handling.
+ */
+#[Group('gitleaks')]
+class GitleaksCommandsChecksumTest extends TestCase
+{
+
+    /**
+     * Test method GitleaksCommands::isChecksumValid().
+     */
+    public function testIsChecksumValid(): void
+    {
+        $method = new ReflectionMethod(
+            GitleaksCommands::class,
+            'isChecksumValid'
+        );
+        $method->setAccessible(true);
+
+        $content = 'sample-archive-content';
+        $validSha = hash('sha256', $content);
+
+        $command = new GitleaksCommands();
+
+        $this->assertTrue($method->invoke($command, $content, $validSha));
+        $this->assertFalse($method->invoke($command, $content, str_repeat('0', 64)));
+        $this->assertFalse($method->invoke($command, $content, ''));
+    }
+
+}

--- a/tests/fixtures/commands/gitleaks.yml
+++ b/tests/fixtures/commands/gitleaks.yml
@@ -12,7 +12,7 @@
         [Simulator] Simulating Exec('./vendor/bin/gitleaks directory --no-banner --redact')
         [Simulator] Running ./vendor/bin/gitleaks directory --no-banner --redact
 
-- command: 'toolkit:run-gitleaks --tag=1.0.2 --os=linux_x32'
+- command: 'toolkit:run-gitleaks --tag=1.0.2 --os=linux_x32 --sha256=deadbeef'
   expectations:
     - contains: |
         Downloading from https://github.com/gitleaks/gitleaks/releases/download/v1.0.2/gitleaks_1.0.2_linux_x32.tar.gz


### PR DESCRIPTION
On every run, GitLab pipelines install Gitleaks binary directly from a GitHub release without verifying its checksum. This means that if the upstream source is compromised the pipeline would silently download and execute malicious code with no detection.

This is not a theoretical risk, we have seen it happen recently with xz/liblzma, several npm packages, and the Trivy GitHub Action incident, among others.

To mitigate this, the binary downloaded from GitHub in the pipeline should have its SHA-256 checksum verified before execution.