### PR TITLE
Add xdebug_break() to the list of forbidden functions

### DIFF
--- a/phpcs/QualityAssurance/Sniffs/Functions/DrupalWrappersSniff.php
+++ b/phpcs/QualityAssurance/Sniffs/Functions/DrupalWrappersSniff.php
@@ -54,6 +54,7 @@ class DrupalWrappersSniff extends ForbiddenFunctionsSniff
         'strtolower'                 => 'mb_strtolower',
         'strtoupper'                 => 'mb_strtoupper',
         'date'                       => 'Drupal::service("date.formatter")->format',
+        'xdebug_break'               => null,
     ];
 
     /**


### PR DESCRIPTION
The function `xdebug_break()` should never be committed, so I think it is good candidate to be included in the list of forbidden functions.