### PR TITLE
Return error on gitleaks command in case of findings not ignored

### DIFF
--- a/src/TaskRunner/Commands/GitleaksCommands.php
+++ b/src/TaskRunner/Commands/GitleaksCommands.php
@@ -115,7 +115,7 @@ class GitleaksCommands extends AbstractCommands
         }
 
         $this->printReport($report, $findings);
-        return ResultData::EXITCODE_OK;
+        return $report['found'] <= $report['ignored'] ? ResultData::EXITCODE_OK : ResultData::EXITCODE_ERROR;
     }
 
     /**


### PR DESCRIPTION
With the improvement implemented #873 (DQA-14193), the gitleaks command is always returning OK, even if there are new findings. 