### PR TITLE
Fix dist path replacement removing dist from middle of paths

### DIFF
--- a/src/TaskRunner/Commands/GitleaksCommands.php
+++ b/src/TaskRunner/Commands/GitleaksCommands.php
@@ -201,8 +201,8 @@ class GitleaksCommands extends AbstractCommands
         $dist = $this->getConfigValue('toolkit.build.dist.root');
         foreach ($findings as $index => &$finding) {
             // Remove dist part from the paths.
-            $finding['File'] = ltrim(str_replace("$dist/", '', $finding['File']), '/');
-            $finding['Fingerprint'] = ltrim(str_replace("$dist/", '', $finding['Fingerprint']), '/');
+            $finding['File'] = ltrim(preg_replace('#' . preg_quote("$dist/", '#') . '#', '', $finding['File'], 1), '/');
+            $finding['Fingerprint'] = ltrim(preg_replace('#' . preg_quote("$dist/", '#') . '#', '', $finding['Fingerprint'], 1), '/');
             // Build the fingerprint using the relative path to the file,
             // the secret found and the rule id.
             $finding['ToolkitFingerprint'] = hash('sha256', "{$finding['File']}:{$finding['Secret']}:{$finding['RuleID']}");


### PR DESCRIPTION
`str_replace` replaces **all** occurrences of the dist folder in the path, which corrupts paths that legitimately contain `dist/` in the middle (e.g., `web/libraries/unitegallery/dist/js/unitegallery.min.js`).

Replaced with `preg_replace` using a limit of 1, so only the first occurrence is removed.